### PR TITLE
Add .dockerignore to optimize Docker Build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.git
+Dockerfile
+docker-compose.yml
+*.md
+*.log
+.env
+dist
+.vscode


### PR DESCRIPTION
"This file excludes unnecessary files like node_modules, .git, logs, and local configs from being copied into the Docker image. Helps reduce image size and build time."